### PR TITLE
Feature/update to ecs 1.5.0

### DIFF
--- a/buildSrc/src/main/java/io/jsq/ecs/model/FieldSchema.java
+++ b/buildSrc/src/main/java/io/jsq/ecs/model/FieldSchema.java
@@ -28,6 +28,7 @@ public final class FieldSchema {
     private final String outputFormat;
     private final Double outputPrecision;
     private final Integer ignoreAbove;
+    private final List<String> normalize;
 
     private FieldSchema(Builder builder) {
         name = Objects.requireNonNull(builder.name);
@@ -55,6 +56,11 @@ public final class FieldSchema {
         outputFormat = builder.outputFormat;
         outputPrecision = builder.outputPrecision;
         ignoreAbove = builder.ignoreAbove;
+
+        normalize = Optional.ofNullable(builder.normalize)
+                .map(ArrayList::new)
+                .map(Collections::unmodifiableList)
+                .orElse(null);
     }
 
     public static Builder builder() {
@@ -129,6 +135,10 @@ public final class FieldSchema {
         return Optional.ofNullable(ignoreAbove);
     }
 
+    public Optional<List<String>> getNormalize() {
+        return Optional.ofNullable(normalize);
+    }
+
     public Builder toBuilder() {
         Builder builder = builder()
                 .name(getName())
@@ -149,6 +159,7 @@ public final class FieldSchema {
         getOutputFormat().ifPresent(builder::outputFormat);
         getOutputPrecision().ifPresent(builder::outputPrecision);
         getIgnoreAbove().ifPresent(builder::ignoreAbove);
+        getNormalize().ifPresent(builder::normalize);
 
         return builder;
     }
@@ -190,6 +201,7 @@ public final class FieldSchema {
         @JsonProperty("output_format") private String outputFormat;
         @JsonProperty("output_precision") private Double outputPrecision;
         @JsonProperty("ignore_above") private Integer ignoreAbove;
+        private List<String> normalize;
 
         public Builder name(String name) {
             this.name = name;
@@ -273,6 +285,11 @@ public final class FieldSchema {
 
         public Builder ignoreAbove(Integer ignoreAbove) {
             this.ignoreAbove = ignoreAbove;
+            return this;
+        }
+
+        public Builder normalize(List<String> normalize) {
+            this.normalize = normalize;
             return this;
         }
 

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/README.md
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/README.md
@@ -30,11 +30,15 @@ Supported keys to describe fields
 - level (required, one of: core, extended): ECS Level of maturity of the field
 - type (required): Type of the field. Must be set explicitly, no default.
 - required (TBD): TBD if still relevant.
-- short (optional): Optional shorter definition, for display in tight spaces
+- short (optional): Optional shorter definition, for display in tight spaces.
+  Derived automatically if description is short enough.
 - description (required): Description of the field
 - example (optional): A single value example of what can be expected in this field
-- multi\_fields (optional):
+- multi\_fields (optional): Specify additional ways to index the field.
 - index (optional): If `False`, means field is not indexed (overrides type)
+- format: Field format that can be used in a Kibana index template.
+- normalize: Normalization steps that should be applied at ingestion time. Supported values:
+  - array: the content of the field should be an array (even when there's only one value).
 
 Supported keys to describe expected values for a field
 

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/base.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/base.yml
@@ -32,12 +32,14 @@
       example: "[\"production\", \"env2\"]"
       description: >
         List of keywords used to tag each event.
+      normalize:
+        - array
 
     - name: labels
       level: core
       type: object
       object_type: keyword
-      example: {env: production, application: foo-bar}
+      example: {application: foo-bar, env: production}
       short: Custom key/value pairs.
       description: >
         Custom key/value pairs.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/code_signature.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/code_signature.yml
@@ -1,0 +1,60 @@
+---
+- name: code_signature
+  title: Code Signature
+  group: 2
+  description: These fields contain information about binary code signatures.
+  type: group
+  reusable:
+    top_level: false
+    expected:
+      - file
+      - process
+      - process.parent
+      - dll
+      # - driver
+  fields:
+
+    - name: exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: "true"
+
+    - name: subject_name
+      level: core
+      type: keyword
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+
+    - name: valid
+      level: extended
+      type: boolean
+      short: Boolean to capture if the digital signature is verified against the binary content.
+      example: "true"
+      description: >
+        Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.
+
+    - name: trusted
+      level: extended
+      type: boolean
+      short: Stores the trust status of the certificate chain.
+      example: "true"
+      description: >
+        Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated
+        by tools that actively check the status.
+
+
+    - name: status
+      level: extended
+      type: keyword
+      short: Additional information about the certificate status.
+      description: >
+        Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status.
+        Leave unpopulated if the validity or trust of the certificate was unchecked.
+      example: ERROR_UNTRUSTED_ROOT

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/container.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/container.yml
@@ -34,7 +34,9 @@
       level: extended
       type: keyword
       description: >
-        Container image tag.
+        Container image tags.
+      normalize:
+        - array
 
     - name: name
       level: extended

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/dll.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/dll.yml
@@ -1,0 +1,31 @@
+---
+- name: dll
+  title: DLL
+  group: 2
+  short: These fields contain information about code libraries dynamically loaded into processes.
+  description: |-
+    These fields contain information about code libraries dynamically loaded into processes.
+
+    Many operating systems refer to "shared code libraries" with different names, but this field set refers to all of the following:
+    * Dynamic-link library (`.dll`) commonly used on Windows
+    * Shared Object (`.so`) commonly used on Unix-like operating systems
+    * Dynamic library (`.dylib`) commonly used on macOS
+  type: group
+
+  fields:
+
+    - name: name
+      level: core
+      type: keyword
+      short: Name of the library.
+      description: >
+        Name of the library.
+
+        This generally maps to the name of the file on disk.
+      example: kernel32.dll
+
+    - name: path
+      level: extended
+      type: keyword
+      description: Full file path of the library.
+      example: C:\Windows\System32\kernel32.dll

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/dns.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/dns.yml
@@ -54,6 +54,8 @@
 
         Expected values are: AA, TC, RD, RA, AD, CD, DO.
       example: [RD, RA]
+      normalize:
+        - array
 
     - name: response_code
       level: extended
@@ -142,6 +144,8 @@
         At minimum, answer objects must contain the `data` key.
         If more information is available, map as much of it to ECS as possible,
         and add any additional fields to the answer objects as custom fields.
+      normalize:
+        - array
 
     - name: answers.name
       level: extended
@@ -199,3 +203,5 @@
         `dns.resolved_ip` makes it possible to index them as IP addresses, and
         makes them easier to visualize and query for.
       example: [10.10.10.10, 10.10.10.11]
+      normalize:
+        - array

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/event.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/event.yml
@@ -11,10 +11,11 @@
     Examples of log events include a process starting on a host,
     a network packet being sent from a source to a destination,
     or a network connection between a client and a server being initiated or closed.
-    A metric is defined as an event containing one or more numerical or
-    categorical measurements and the time at which the measurement was taken.
-    Examples of metric events include memory pressure measured on a host,
-    or vulnerabilities measured on a scanned host.
+    A metric is defined as an event containing one or more numerical measurements
+    and the time at which the measurement was taken. Examples of metric events include
+    memory pressure measured on a host and device temperature.
+    See the `event.kind` definition in this section for additional details about
+    metric and state events.
   type: group
   fields:
 
@@ -68,19 +69,33 @@
             It is used to represent events that indicate that something happened.
         - name: metric
           description: >
-            This value is used to indicate that this event that a numeric measurement
-            was taken at given point in time.
+            This value is used to indicate that this event describes a numeric measurement
+            taken at given point in time.
 
-            Examples include CPU utilization, memory usage, or a vulnerability scan result.
+            Examples include CPU utilization, memory usage, or device temperature.
 
             Metric events are often collected on a predictable frequency, such as once
-            every few seconds, or once a minute.
+            every few seconds, or once a minute, but can also be used to
+            describe ad-hoc numeric metric queries.
         - name: state
           description: >
-            This value is similar to metric, except that the entity being measured does not
-            provide a numeric metric value, but rather one of a fixed set of conditions or states.
-            For example a periodic event reporting a "fin_wait" state of a TCP connection
-            on a host might use `event.type:state`.
+            The state value is similar to metric, indicating that this event describes a
+            measurement taken at given point in time, except that the measurement does not
+            result in a numeric value, but rather one of a fixed set of categorical values
+            that represent conditions or states.
+
+            Examples include periodic events reporting Elasticsearch cluster state (green/yellow/red),
+            the state of a TCP connection (open, closed, fin_wait, etc.), the state of a host with respect
+            to a software vulnerability (vulnerable, not vulnerable), and the state of a system
+            regarding compliance with a regulatory standard (compliant, not compliant).
+
+            Note that an event that describes a change of state would not use `event.kind:state`,
+            but instead would use 'event.kind:event' since a state change fits the more general
+            event definition of something that happened.
+
+            State events are often collected on a predictable frequency, such as once
+            every few seconds, once a minute, once an hour, or once a day, but can also be used to
+            describe ad-hoc state queries.
         - name: pipeline_error
           description: >
             This value indicates that an error occurred during the ingestion of this event,
@@ -112,6 +127,8 @@
         This field is an array. This will allow proper categorization of some events
         that fall in multiple categories.
       example: authentication
+      normalize:
+        - array
       allowed_values:
         - name: authentication
           description: >
@@ -177,6 +194,19 @@
             - end
             - info
             - start
+        - name: iam
+          description: >
+            Identity and access management (IAM) events relating to users, groups, and administration.
+            Use this category to visualize and analyze IAM-related logs and data from active directory,
+            LDAP, Okta, Duo, and other IAM systems.
+          expected_event_types:
+            - admin
+            - change
+            - creation
+            - deletion
+            - group
+            - info
+            - user
         - name: intrusion_detection
           description: >
             Relating to intrusion detections from IDS/IPS systems and functions,
@@ -184,6 +214,8 @@
             intrusion detection alerts from systems such as Snort, Suricata,
             and Palo Alto threat detections.
           expected_event_types:
+            - allowed
+            - denied
             - info
         - name: malware
           description: >
@@ -194,6 +226,22 @@
             Palo Alto Networks threat logs and Wildfire logs.
           expected_event_types:
             - info
+        - name: network
+          description: >
+            Relating to all network activity, including network connection lifecycle,
+            network traffic, and essentially any event that includes an IP address. Many events
+            containing decoded network protocol transactions fit into this category.
+            Use events in this category to visualize or analyze counts of network ports,
+            protocols, addresses, geolocation information, etc.
+          expected_event_types:
+            - access
+            - allowed
+            - connection
+            - denied
+            - end
+            - info
+            - protocol
+            - start
         - name: package
           description: >
             Relating to software packages installed on hosts. Use this category to
@@ -242,14 +290,24 @@
     - name: outcome
       level: core
       type: keyword
-      short: The outcome of the event. The lowest categorization field in the hierarchy.
+      short: The outcome of the event. The lowest level categorization field in the hierarchy.
       description: >
         This is one of four ECS Categorization Fields, and indicates the
         lowest level in the ECS category hierarchy.
 
-        `event.outcome` simply denotes whether the event represent a success or a failure.
-        Note that not all events will have an associated outcome. For example, this field is
-        generally not populated for metric events or events with `event.type:info`.
+        `event.outcome` simply denotes whether the event represents a success or a failure from
+        the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may
+        populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events),
+        this field should be populated with the value that best captures the overall success or failure from
+        the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is
+        generally not populated for metric events, events with `event.type:info`, or any events for
+        which an outcome does not make logical sense.
       example: success
       allowed_values:
         - name: failure
@@ -259,15 +317,18 @@
             to indicate that a file access was attempted, but was not successful.
         - name: success
           description: >
-            Indicates that this event describes a successful result.  A common example is
+            Indicates that this event describes a successful result. A common example is
             `event.category:file AND event.type:create AND event.outcome:success`
             to indicate that a file was successfully created.
         - name: unknown
           description: >
             Indicates that this event describes only an attempt for which the result
-            is unknown. For example, if the event contains information only about a
-            request in an entity transaction that usually results in a response,
-            populating `event.outcome:unknown` is appropriate.
+            is unknown from the perspective of the event producer.
+            For example, if the event contains information only about the request side
+            of a transaction that results in a response, populating `event.outcome:unknown`
+            in the request event is appropriate.
+            The unknown value should not be used when an outcome doesn't make logical sense for
+            the event. In such cases `event.outcome` should not be populated.
 
     - name: type
       level: core
@@ -283,6 +344,8 @@
 
         This field is an array. This will allow proper categorization of some events
         that fall in multiple event types.
+      normalize:
+        - array
       allowed_values:
         - name: access
           description: >
@@ -293,6 +356,27 @@
             Note for file access, both directory listings and file opens should be included
             in this subcategory. You can further distinguish access operations using the ECS
             `event.action` field.
+        - name: admin
+          description: >
+            The admin event type is used for the subset of events within a category
+            that are related to admin objects. For example, administrative changes within
+            an IAM framework that do not specifically affect a user or group (e.g., adding new
+            applications to a federation solution or connecting discrete forests in Active Directory)
+            would fall into this subcategory.
+            Common example: `event.category:iam AND event.type:change AND event.type:admin`.
+            You can further distinguish admin operations using the ECS
+            `event.action` field.
+        - name: allowed
+          description: >
+            The allowed event type is used for the subset of events within a category that
+            indicate that something was allowed. Common examples include
+            `event.category:network AND event.type:connection AND event.type:allowed` (to indicate a network
+            firewall event for which the firewall disposition was to allow the connection to complete)
+            and `event.category:intrusion_detection AND event.type:allowed` (to indicate a network
+            intrusion prevention system event for which the IPS disposition was to allow the connection
+            to complete). You can further distinguish allowed operations using the ECS
+            `event.action` field, populating with values of your choosing, such as "allow", "detect", or
+            "pass".
         - name: change
           description: >
             The change event type is used for the subset of events within a category
@@ -301,6 +385,22 @@
             Common examples include `event.category:process AND event.type:change`,
             and `event.category:file AND event.type:change`.
             You can further distinguish change operations using the ECS `event.action` field.
+        - name: connection
+          description: >
+            Used primarily with `event.category:network` this value is used for the subset of
+            network traffic that includes sufficient information for the event to be included
+            in flow or connection analysis. Events in this subcategory will contain at least
+            source and destination IP addresses, source and destination TCP/UDP ports, and will usually
+            contain counts of bytes and/or packets transferred. Events in this subcategory may contain
+            unidirectional or bidirectional information, including summary information.
+            Use this subcategory to visualize and analyze network connections. Flow analysis, including
+            Netflow, IPFIX, and other flow-related events fit in this subcategory. Note that firewall
+            events from many Next-Generation Firewall (NGFW) devices will also fit into this subcategory.  A common filter for
+            flow/connection information would be
+            `event.category:network AND event.type:connection AND event.type:end` (to view or analyze all
+            completed network connections, ignoring mid-flow reports). You can further distinguish connection
+            events using the ECS `event.action` field, populating with values of your choosing, such as
+            "timeout", or "reset".
         - name: creation
           description: >
             The "creation" event type is used for the subset of events within a category
@@ -312,6 +412,17 @@
             that indicate that something was deleted.
             A common example is `event.category:file AND event.type:deletion`
             to indicate that a file has been deleted.
+        - name: denied
+          description: >
+            The denied event type is used for the subset of events within a category that
+            indicate that something was denied. Common examples include
+            `event.category:network AND event.type:denied` (to indicate a network
+            firewall event for which the firewall disposition was to deny the connection)
+            and `event.category:intrusion_detection AND event.type:denied` (to indicate a network
+            intrusion prevention system event for which the IPS disposition was to deny the connection
+            to complete). You can further distinguish denied operations using the ECS
+            `event.action` field, populating with values of your choosing, such as "blocked", "dropped", or
+            "quarantined".
         - name: end
           description: >
             The end event type is used for the subset of events within a category
@@ -325,6 +436,13 @@
             Note that pipeline errors that occur during the event ingestion process
             should not use this `event.type` value. Instead, they should use
             `event.kind:pipeline_error`.
+        - name: group
+          description: >
+            The group event type is used for the subset of events within a category
+            that are related to group objects.
+            Common example: `event.category:iam AND event.type:creation AND event.type:group`.
+            You can further distinguish group operations using the ECS
+            `event.action` field.
         - name: info
           description: >
             The info event type is used for the subset of events within a category
@@ -340,11 +458,35 @@
             The installation event type is used for the subset of events within a category
             that indicate that something was installed.
             A common example is `event.category:package` AND `event.type:installation`.
+        - name: protocol
+          description: >
+            The protocol event type is used for the subset of events within a category that
+            indicate that they contain protocol details or analysis, beyond simply identifying the protocol.
+            Generally, network events that contain specific protocol details will fall into this subcategory.
+            A common example is `event.category:network AND event.type:protocol AND event.type:connection AND event.type:end`
+            (to indicate that the event is a network connection event sent at the end of a connection
+            that also includes a protocol detail breakdown).
+            Note that events that only indicate the name or id of the protocol should not use the protocol value.
+            Further note that when the protocol subcategory is used, the identified protocol is populated in
+            the ECS `network.protocol` field.
+          expected_event_types:
+            - access
+            - change
+            - end
+            - info
+            - start
         - name: start
           description: >
             The start event type is used for the subset of events within a category
             that indicate something has started. A common example is
             `event.category:process AND event.type:start`.
+        - name: user
+          description: >
+            The user event type is used for the subset of events within a category
+            that are related to user objects.
+            Common example: `event.category:iam AND event.type:deletion AND event.type:user`.
+            You can further distinguish user operations using the ECS
+            `event.action` field.
 
     - name: module
       level: core
@@ -458,7 +600,7 @@
         Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the
-        exact ordering of events unambiguous, regarless of the timestamp precision.
+        exact ordering of events unambiguous, regardless of the timestamp precision.
 
     - name: timezone
       level: extended
@@ -476,7 +618,7 @@
       level: core
       type: date
       short: Time when the event was first read by an agent or by your pipeline.
-      example: 2016-05-23T08:05:34.857Z
+      example: '2016-05-23T08:05:34.857Z'
       description: >
         event.created contains the date/time when the event was first read by an
         agent, or by your pipeline.
@@ -527,7 +669,7 @@
       level: core
       type: date
       short: Timestamp when an event arrived in the central data store.
-      example: 2016-05-23T08:05:35.101Z
+      example: '2016-05-23T08:05:35.101Z'
       description: >
         Timestamp when an event arrived in the central data store.
 
@@ -537,3 +679,28 @@
 
         In normal conditions, assuming no tampering, the timestamps should
         chronologically look like this: `@timestamp` < `event.created` < `event.ingested`.
+
+    - name: reference
+      level: extended
+      type: keyword
+      short: Event reference URL
+      description: >
+        Reference URL linking to additional information about this event.
+
+        This URL links to a static definition of the this event.
+        Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+      example: https://system.vendor.com/event/#0001234
+
+    - name: url
+      level: extended
+      type: keyword
+      short: Event investigation URL
+      description: >
+        URL linking to an external system to continue investigation of this event.
+
+        This URL links to another
+        system where in-depth investigation of the specific occurence of this event can take place.
+        Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/file.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/file.yml
@@ -4,167 +4,178 @@
   title: File
   short: Fields describing files.
   description: >
-     A file is defined as a set of information that has been created on, or has existed on a filesystem.
+    A file is defined as a set of information that has been created on, or has existed on a filesystem.
 
-     File objects can be associated with host events, network events,
-     and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services).
-     File fields provide details about the affected file associated with the event or metric.
+    File objects can be associated with host events, network events,
+    and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services).
+    File fields provide details about the affected file associated with the event or metric.
   type: group
   fields:
+    - name: name
+      level: extended
+      type: keyword
+      description: Name of the file including the extension, without the directory.
+      example: example.png
 
-  - name: name
-    level: extended
-    type: keyword
-    description: Name of the file including the extension, without the directory.
-    example: example.png
+    - name: attributes
+      level: extended
+      type: keyword
+      short: Array of file attributes.
+      description: >
+        Array of file attributes.
 
-  - name: attributes
-    level: extended
-    type: keyword
-    short: Array of file attributes.
-    description: >
-      Array of file attributes.
+        Attributes names will vary by platform. Here's a non-exhaustive list of values
+        that are expected in this field: archive, compressed, directory, encrypted,
+        execute, hidden, read, readonly, system, write.
+      example: '["readonly", "system"]'
+      normalize:
+        - array
 
-      Attributes names will vary by platform. Here's a non-exhaustive list of values
-      that are expected in this field: archive, compressed, directory, encrypted,
-      execute, hidden, read, readonly, system, write.
-    example: '["readonly", "system"]'
+    - name: directory
+      level: extended
+      type: keyword
+      short: Directory where the file is located.
+      description: >
+        Directory where the file is located. It should include the drive letter,
+        when appropriate.
+      example: "/home/alice"
 
-  - name: directory
-    level: extended
-    type: keyword
-    short: Directory where the file is located.
-    description: >
-      Directory where the file is located. It should include the drive letter,
-      when appropriate.
-    example: '/home/alice'
+    - name: drive_letter
+      level: extended
+      type: keyword
+      ignore_above: 1
+      short: Drive letter where the file is located.
+      description: >
+        Drive letter where the file is located. This field is only relevant on Windows.
 
-  - name: drive_letter
-    level: extended
-    type: keyword
-    ignore_above: 1
-    short: Drive letter where the file is located.
-    description: >
-      Drive letter where the file is located. This field is only relevant on Windows.
+        The value should be uppercase, and not include the colon.
+      example: C
 
-      The value should be uppercase, and not include the colon.
-    example: C
+    - name: path
+      level: extended
+      type: keyword
+      short: Full path to the file, including the file name.
+      description: >
+        Full path to the file, including the file name. It should include the
+        drive letter, when appropriate.
+      example: "/home/alice/example.png"
+      multi_fields:
+        - type: text
+          name: text
 
-  - name: path
-    level: extended
-    type: keyword
-    short: Full path to the file, including the file name.
-    description: >
-      Full path to the file, including the file name. It should include the
-      drive letter, when appropriate.
-    example: '/home/alice/example.png'
-    multi_fields:
-    - type: text
-      name: text
+    - name: target_path
+      level: extended
+      type: keyword
+      description: Target path for symlinks.
+      multi_fields:
+        - type: text
+          name: text
 
-  - name: target_path
-    level: extended
-    type: keyword
-    description: Target path for symlinks.
-    multi_fields:
-    - type: text
-      name: text
+    - name: extension
+      level: extended
+      type: keyword
+      description: File extension.
+      example: png
 
-  - name: extension
-    level: extended
-    type: keyword
-    description: File extension.
-    example: png
+    - name: type
+      level: extended
+      type: keyword
+      description: File type (file, dir, or symlink).
+      example: file
 
-  - name: type
-    level: extended
-    type: keyword
-    description: File type (file, dir, or symlink).
-    example: file
+    - name: device
+      level: extended
+      type: keyword
+      description: Device that is the source of the file.
+      example: sda
 
-  - name: device
-    level: extended
-    type: keyword
-    description: Device that is the source of the file.
-    example: sda
+    - name: inode
+      level: extended
+      type: keyword
+      description: Inode representing the file in the filesystem.
+      example: "256383"
 
-  - name: inode
-    level: extended
-    type: keyword
-    description: Inode representing the file in the filesystem.
-    example: '256383'
+    - name: uid
+      level: extended
+      type: keyword
+      description: >
+        The user ID (UID) or security identifier (SID) of the file owner.
+      example: "1001"
 
-  - name: uid
-    level: extended
-    type: keyword
-    description: >
-      The user ID (UID) or security identifier (SID) of the file owner.
-    example: '1001'
+    - name: owner
+      level: extended
+      type: keyword
+      description: File owner's username.
+      example: alice
 
-  - name: owner
-    level: extended
-    type: keyword
-    description: File owner's username.
-    example: alice
+    - name: gid
+      level: extended
+      type: keyword
+      description: Primary group ID (GID) of the file.
+      example: "1001"
 
-  - name: gid
-    level: extended
-    type: keyword
-    description: Primary group ID (GID) of the file.
-    example: '1001'
+    - name: group
+      level: extended
+      type: keyword
+      description: Primary group name of the file.
+      example: alice
 
-  - name: group
-    level: extended
-    type: keyword
-    description: Primary group name of the file.
-    example: alice
+    - name: mode
+      level: extended
+      type: keyword
+      description: Mode of the file in octal representation.
+      example: "0640"
 
-  - name: mode
-    level: extended
-    type: keyword
-    description: Mode of the file in octal representation.
-    example: '0640'
+    - name: size
+      level: extended
+      type: long
+      short: File size in bytes.
+      description: >
+        File size in bytes.
 
-  - name: size
-    level: extended
-    type: long
-    short: File size in bytes.
-    description: >
-      File size in bytes.
+        Only relevant when `file.type` is "file".
+      example: 16384
 
-      Only relevant when `file.type` is "file".
-    example: 16384
+    - name: mtime
+      level: extended
+      type: date
+      description: Last time the file content was modified.
 
-  - name: mtime
-    level: extended
-    type: date
-    description: Last time the file content was modified.
+    - name: ctime
+      level: extended
+      type: date
+      short: Last time the file attributes or metadata changed.
+      description: >
+        Last time the file attributes or metadata changed.
 
-  - name: ctime
-    level: extended
-    type: date
-    short: Last time the file attributes or metadata changed.
-    description: >
-      Last time the file attributes or metadata changed.
+        Note that changes to the file content will update `mtime`. This implies
+        `ctime` will be adjusted at the same time, since `mtime` is an attribute
+        of the file.
 
-      Note that changes to the file content will update `mtime`. This implies
-      `ctime` will be adjusted at the same time, since `mtime` is an attribute
-      of the file.
+    - name: created
+      level: extended
+      type: date
+      short: File creation time.
+      description: >
+        File creation time.
 
-  - name: created
-    level: extended
-    type: date
-    short: File creation time.
-    description: >
-      File creation time.
+        Note that not all filesystems store the creation time.
 
-      Note that not all filesystems store the creation time.
+    - name: accessed
+      level: extended
+      type: date
+      short: Last time the file was accessed.
+      description: >
+        Last time the file was accessed.
 
-  - name: accessed
-    level: extended
-    type: date
-    short: Last time the file was accessed.
-    description: >
-      Last time the file was accessed.
+        Note that not all filesystems keep track of access time.
 
-      Note that not all filesystems keep track of access time.
+    - name: mime_type
+      level: extended
+      type: keyword
+      short: Media type of file, document, or arrangement of bytes.
+      description: >
+        MIME type should identify the format of the file or stream of bytes using
+        https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types],
+        where possible. When more than one type is applicable, the most specific
+        type should be used.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/hash.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/hash.yml
@@ -16,6 +16,8 @@
     expected:
       - file
       - process
+      - process.parent
+      - dll
 
   fields:
 

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/host.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/host.yml
@@ -43,17 +43,22 @@
         in your environment.
 
         Example: The current usage of `beat.name`.
+
     - name: ip
       level: core
       type: ip
       description: >
-        Host ip address.
+        Host ip addresses.
+      normalize:
+        - array
 
     - name: mac
       level: core
       type: keyword
       description: >
-        Host mac address.
+        Host mac addresses.
+      normalize:
+        - array
 
     - name: type
       level: core
@@ -85,9 +90,9 @@
       type: keyword
       short: Name of the directory the group is a member of.
       description: >
-        Name of the domain of which the host is a member. 
+        Name of the domain of which the host is a member.
 
-        For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. 
+        For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name.
         For Linux this could be the domain of the host's LDAP provider.
       example: CONTOSO
 

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/interface.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/interface.yml
@@ -1,0 +1,44 @@
+- name: interface
+  title: Interface
+  group: 2
+  short: Fields to describe observer interface information.
+  description: >
+    The interface fields are used to record ingress and egress interface information when
+    reported by an observer (e.g. firewall, router, load balancer) in the context of the
+    observer handling a network connection.  In the case of a single observer interface
+    (e.g. network sensor on a span port) only the observer.ingress information should be
+    populated.
+
+  reusable:
+    top_level: false
+    expected:
+      - observer.ingress
+      - observer.egress
+
+  type: group
+  fields:
+
+    - name: id
+      level: extended
+      type: keyword
+      short: Interface ID
+      example: 10
+      description: >
+        Interface ID as reported by an observer (typically SNMP interface ID).
+
+    - name: name
+      level: extended
+      type: keyword
+      short: Interface name
+      example: eth0
+      description: >
+        Interface name as reported by the system.
+
+    - name: alias
+      level: extended
+      type: keyword
+      short: Interface alias
+      example: outside
+      description: >
+        Interface alias as reported by the system, typically used in firewall implementations for e.g.
+        inside, outside, or dmz logical interface naming.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/manifest
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/manifest
@@ -3,8 +3,10 @@ as.yml
 base.yml
 client.yml
 cloud.yml
+code_signature.yml
 container.yml
 destination.yml
+dll.yml
 dns.yml
 ecs.yml
 error.yml
@@ -15,12 +17,14 @@ group.yml
 hash.yml
 host.yml
 http.yml
+interface.yml
 log.yml
 network.yml
 observer.yml
 organization.yml
 os.yml
 package.yml
+pe.yml
 process.yml
 registry.yml
 related.yml
@@ -34,4 +38,5 @@ tracing.yml
 url.yml
 user.yml
 user_agent.yml
+vlan.yml
 vulnerability.yml

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/network.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/network.yml
@@ -138,3 +138,14 @@
 
         If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
       example: 24
+    
+    # q-in-q vlan fields for identifying 802.1q nested vlans
+    - name: inner
+      level: extended
+      type: object
+      short: Inner VLAN tag information
+      description: >
+        Network.inner fields are added in addition to network.vlan fields to describe 
+        the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include 
+        vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic
+        with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/observer.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/observer.yml
@@ -21,13 +21,17 @@
       level: core
       type: keyword
       description: >
-        MAC address of the observer
+        MAC addresses of the observer
+      normalize:
+        - array
 
     - name: ip
       level: core
       type: ip
       description: >
-        IP address of the observer.
+        IP addresses of the observer.
+      normalize:
+        - array
 
     - name: hostname
       level: core
@@ -86,3 +90,39 @@
         There is no predefined list of observer types. Some examples are
         `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`.
       example: firewall
+
+    - name: ingress
+      level: extended
+      type: object
+      short: Object field for ingress information
+      description: >
+        Observer.ingress holds information like interface number and name, vlan, and zone information to 
+        classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should 
+        only use observer.ingress to categorize traffic.
+
+    - name: ingress.zone
+      level: extended
+      type: keyword
+      short: Observer ingress zone
+      example: DMZ
+      description: >
+        Network zone of incoming traffic as reported by the observer to categorize the source area of ingress 
+        traffic. e.g. internal, External, DMZ, HR, Legal, etc.
+      
+    - name: egress
+      level: extended
+      type: object
+      short: Object field for egress information
+      description: >
+        Observer.egress holds information like interface number and name, vlan, and zone information to 
+        classify egress traffic.  Single armed monitoring such as a network sensor on a span port should 
+        only use observer.ingress to categorize traffic.
+
+    - name: egress.zone
+      level: extended
+      type: keyword
+      short: Observer Egress zone
+      example: Public_Internet
+      description: >
+        Network zone of outbound traffic as reported by the observer to categorize the destination area of egress 
+        traffic, e.g. Internal, External, DMZ, HR, Legal, etc.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/pe.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/pe.yml
@@ -1,0 +1,47 @@
+---
+- name: pe
+  title: PE Header
+  group: 2
+  description: These fields contain Windows Portable Executable (PE) metadata.
+  type: group
+  reusable:
+    top_level: false
+    expected:
+      - file
+      - dll
+      - process
+  fields:
+
+    - name: original_file_name
+      level: extended
+      type: keyword
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+
+
+    - name: file_version
+      level: extended
+      type: keyword
+      short: Process name.
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+
+
+    - name: description
+      level: extended
+      type: keyword
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+
+    - name: product
+      level: extended
+      type: keyword
+      description: Internal product name of the file, provided at compile-time.
+      example: Microsoft® Windows® Operating System
+
+
+    - name: company
+      level: extended
+      type: keyword
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/process.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/process.yml
@@ -42,6 +42,39 @@
         Process id.
       example: 4242
 
+    - name: entity_id
+      level: extended
+      type: keyword
+      short: Unique identifier for the process.
+      description: >
+        Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some
+        examples of what could be used here are a process-generated UUID,
+        Sysmon Process GUIDs, or a hash of some uniquely identifying components
+        of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.
+      example: c2c455d9f99375d
+
+    - name: parent.entity_id
+      level: extended
+      type: keyword
+      short: Unique identifier for the process.
+      description: >
+        Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some
+        examples of what could be used here are a process-generated UUID,
+        Sysmon Process GUIDs, or a hash of some uniquely identifying components
+        of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.
+      example: c2c455d9f99375d
 
     - name: name
       level: extended
@@ -140,6 +173,8 @@
 
         May be filtered to protect sensitive information.
       example: ["/usr/bin/ssh", "-l", "user", "10.0.0.16"]
+      normalize:
+        - array
 
     - name: parent.args
       level: extended
@@ -150,6 +185,8 @@
 
         May be filtered to protect sensitive information.
       example: ["ssh", "-l", "user", "10.0.0.16"]
+      normalize:
+        - array
 
     - name: args_count
       level: extended

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/related.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/related.yml
@@ -13,7 +13,7 @@
     A concrete example is IP addresses, which can be under host, observer, source,
     destination, client, server, and network.forwarded_ip.
     If you append all IPs to `related.ip`, you can then search for a given IP trivially,
-    no matter where it appeared, by querying `related.ip:a.b.c.d`.
+    no matter where it appeared, by querying `related.ip:192.0.2.15`.
   type: group
   fields:
 
@@ -22,9 +22,24 @@
       type: ip
       description: >
         All of the IPs seen on your event.
+      normalize:
+        - array
 
     - name: user
       level: extended
       type: keyword
       description: >
         All the user names seen on your event.
+      normalize:
+        - array
+
+    - name: hash
+      level: extended
+      type: keyword
+      short: All the hashes seen on your event.
+      description: >
+        All the hashes seen on your event. Populating this field, then using it
+        to search for hashes can help in situations where you're unsure what
+        the hash algorithm is (and therefore which key name to search).
+      normalize:
+        - array

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/rule.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/rule.yml
@@ -6,9 +6,9 @@
   description: >
    Rule fields are used to capture the specifics of any observer or agent rules that generate alerts or other notable events.
 
-   Examples of data sources that would populate the rule fields include: network admission control platforms, network or 
-   host IDS/IPS, network firewalls, web application firewalls, url filters, endpoint detection and response (EDR) systems, etc.  
-  
+   Examples of data sources that would populate the rule fields include: network admission control platforms, network or
+   host IDS/IPS, network firewalls, web application firewalls, url filters, endpoint detection and response (EDR) systems, etc.
+
   type: group
   fields:
 
@@ -19,7 +19,7 @@
       description: >
         A rule ID that is unique within the scope of an agent, observer, or other entity using the rule for detection of this event.
 
-      example: 101 
+      example: 101
 
     - name: uuid
       level: extended
@@ -81,4 +81,22 @@
 
       example: https://en.wikipedia.org/wiki/DNS_over_TLS
 
+    - name: author
+      level: extended
+      type: keyword
+      short: Rule author
+      description: >
+        Name, organization, or pseudonym of the author or authors who created the rule used to generate this event.
 
+      example: ['Star-Lord']
+      normalize:
+        - array
+
+    - name: license
+      level: extended
+      type: keyword
+      short: Rule license
+      description: >
+        Name of the license under which the rule used to generate this event is made available.
+
+      example: Apache 2.0

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/threat.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/threat.yml
@@ -33,6 +33,8 @@
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: impact
+      normalize:
+        - array
 
     - name: tactic.id
       level: extended
@@ -43,6 +45,8 @@
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: TA0040
+      normalize:
+        - array
 
     - name: tactic.reference
       level: extended
@@ -53,6 +57,8 @@
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: https://attack.mitre.org/tactics/TA0040/
+      normalize:
+        - array
 
     - name: technique.name
       level: extended
@@ -66,6 +72,8 @@
           (ex. https://attack.mitre.org/techniques/T1499/ )
 
       example: endpoint denial of service
+      normalize:
+        - array
 
     - name: technique.id
       level: extended
@@ -76,6 +84,8 @@
           (ex. https://attack.mitre.org/techniques/T1499/ )
 
       example: T1499
+      normalize:
+        - array
 
     - name: technique.reference
       level: extended
@@ -86,3 +96,5 @@
           (ex. https://attack.mitre.org/techniques/T1499/ )
 
       example: https://attack.mitre.org/techniques/T1499/
+      normalize:
+        - array

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/tls.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/tls.yml
@@ -72,6 +72,8 @@
       level: extended
       description: Array of ciphers offered by the client during the client hello.
       example: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."]
+      normalize:
+        - array
 
     - name: client.subject
       type: keyword
@@ -105,6 +107,8 @@
         usually mutually-exclusive of `client.certificate` since that value should be the first certificate
         in the chain.
       example: ["MII...", "MII..."]
+      normalize:
+        - array
 
     - name: client.certificate
       type: keyword
@@ -176,6 +180,8 @@
         usually mutually-exclusive of `server.certificate` since that value should be the first certificate
         in the chain.
       example: ["MII...", "MII..."]
+      normalize:
+        - array
 
     - name: server.certificate
       type: keyword

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/tracing.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/tracing.yml
@@ -3,7 +3,7 @@
   title: Tracing
   root: true
   group: 2
-  short: Fields related to distributed tracing. 
+  short: Fields related to distributed tracing.
   description: >
     Distributed tracing makes it possible to analyze performance throughout a microservice architecture all in one view.
     This is accomplished by tracing all of the requests - from the initial web request in the front-end service - to queries made through multiple back-end services.
@@ -19,6 +19,7 @@
 
         A trace groups multiple events like transactions that belong together.
         For example, a user request handled by multiple inter-connected services.
+
     - name: transaction.id
       level: extended
       type: keyword
@@ -26,5 +27,5 @@
       short: Unique identifier of the transaction.
       description: >
         Unique identifier of the transaction.
-        
+
         A transaction is the highest level of work measured within a service, such as a request to a server.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/user.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/user.yml
@@ -25,7 +25,7 @@
       level: core
       type: keyword
       description: >
-        One or multiple unique identifiers of the user.
+        Unique identifiers of the user.
 
     - name: name
       level: core

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/vlan.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/vlan.yml
@@ -1,0 +1,45 @@
+- name: vlan
+  title: VLAN
+  group: 2
+  short: Fields to describe observed VLAN information.
+  description: >
+    The VLAN fields are used to identify 802.1q tag(s) of a packet, as well as ingress and
+    egress VLAN associations of an observer in relation to a specific packet or connection.
+
+    Network.vlan fields are used to record a single VLAN tag, or the outer tag in the case
+    of q-in-q encapsulations, for a packet or connection as observed, typically provided by a
+    network sensor (e.g. Zeek, Wireshark) passively reporting on traffic.
+
+    Network.inner VLAN fields are used to report inner q-in-q 802.1q tags (multiple
+    802.1q encapsulations) as observed, typically provided by a network sensor  (e.g. Zeek,
+    Wireshark) passively reporting on traffic. Network.inner VLAN fields should only be used
+    in addition to network.vlan fields to indicate q-in-q tagging.
+
+    Observer.ingress and observer.egress VLAN values are used to record observer specific
+    information when observer events contain discrete ingress and egress VLAN information,
+    typically provided by firewalls, routers, or load balancers.
+
+  reusable:
+    top_level: false
+    expected:
+      - observer.ingress
+      - observer.egress
+      - network
+      - network.inner
+
+  type: group
+  fields:
+
+    - name: id
+      level: extended
+      type: keyword
+      example: 10
+      description: >
+        VLAN ID as reported by the observer.
+
+    - name: name
+      level: extended
+      type: keyword
+      example: outside
+      description: >
+        Optional VLAN name as reported by the observer.

--- a/buildSrc/src/main/resources/META-INF/elastic-common-schema/vulnerability.yml
+++ b/buildSrc/src/main/resources/META-INF/elastic-common-schema/vulnerability.yml
@@ -107,6 +107,8 @@
         This field must be an array.
 
       example: '["Firewall"]'
+      normalize:
+        - array
 
     - name: description
       level: extended

--- a/buildSrc/src/test/java/io/jsq/ecs/SmithyModelBuilderTest.java
+++ b/buildSrc/src/test/java/io/jsq/ecs/SmithyModelBuilderTest.java
@@ -5,6 +5,10 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeIndex;
 import software.amazon.smithy.model.validation.ValidatedResult;
 
 class SmithyModelBuilderTest {
@@ -17,5 +21,18 @@ class SmithyModelBuilderTest {
 
         Assertions.assertFalse(result.isBroken());
         Assertions.assertTrue(result.getResult().isPresent());
+    }
+
+    @Test
+    void testModelBuilderCorrectlyAppliesArrayNormalization() {
+        List<Schema> schemata = Loader.loadSchemata();
+        SmithyModelBuilder builder = new SmithyModelBuilder("example.test", "Record");
+        schemata.forEach(builder::addSchema);
+        ShapeIndex index = builder.build().unwrap().getShapeIndex();
+
+        Shape rootShape = index.getShape(ShapeId.from("example.test#Record")).get();
+        MemberShape tagsMember = rootShape.asStructureShape().flatMap(ss -> ss.getMember("tags")).get();
+        Shape tagsTarget = index.getShape(tagsMember.getTarget()).get();
+        Assertions.assertTrue(tagsTarget.isListShape());
     }
 }


### PR DESCRIPTION
Update ECS submodule to 1.5.0. 1.5.0 is the first release to support declaring whether a property should be normalized to a list, so the whitelist of known lists in `SmithyModelBuilder` has been removed.